### PR TITLE
Added new Nova fields for managing anime schedules

### DIFF
--- a/app/Anime.php
+++ b/app/Anime.php
@@ -33,6 +33,15 @@ class Anime extends KModel
         ]
     ];
 
+	/**
+	 * Casts rules.
+	 *
+	 * @var array
+	 */
+    protected $casts = [
+	    'first_aired' => 'date'
+    ];
+
     // Maximum amount of returned search results
     const MAX_SEARCH_RESULTS = 10;
 

--- a/app/Enums/DayOfWeek.php
+++ b/app/Enums/DayOfWeek.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+use BenSampo\Enum\Enum;
+
+final class DayOfWeek extends Enum
+{
+    const Sunday    = 0;
+    const Monday    = 1;
+    const Tuesday   = 2;
+	const Wednesday = 3;
+	const Thursday  = 4;
+	const Friday    = 5;
+	const Saturday  = 6;
+}

--- a/app/Http/Resources/AnimeResource.php
+++ b/app/Http/Resources/AnimeResource.php
@@ -40,7 +40,10 @@ class AnimeResource extends JsonResource
             'background'            => $this->getBackground(false),
             'background_thumbnail'  => $this->getBackground(true),
             'nsfw'                  => (bool) $this->nsfw,
-            'genres'                => GenreResource::collection($this->genres)
+            'genres'                => GenreResource::collection($this->genres),
+            'first_aired'           => $this->first_aired,
+	        'air_time'              => $this->air_time,
+	        'air_day'               => $this->air_day
         ];
 
         if(Auth::check())

--- a/app/Nova/Anime.php
+++ b/app/Nova/Anime.php
@@ -6,13 +6,16 @@ use App\Nova\Actions\FetchAnimeActors;
 use App\Nova\Actions\FetchAnimeDetails;
 use App\Nova\Actions\FetchAnimeImages;
 use Chaseconey\ExternalImage\ExternalImage;
+use Laraning\NovaTimeField\TimeField as Time;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Number;
+use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
 
@@ -94,6 +97,7 @@ class Anime extends Resource
                 ->help('The network that airs the Anime.'),
 
             Number::make('TVDB ID', 'tvdb_id')
+	            ->sortable()
                 ->help('The ID of the Anime as noted on The TVDB.'),
 
             Number::make('MAL ID', 'mal_id')
@@ -115,6 +119,41 @@ class Anime extends Resource
             Text::make('Watch rating', 'watch_rating')
                 ->onlyOnForms()
                 ->help('for example: TV-PG.'),
+
+            Heading::make('Schedule')
+	            ->onlyOnForms(),
+
+            Select::make('Air status', 'status')
+	            ->options([
+	            	0 => 'TBA',
+		            1 => 'Ended',
+		            2 => 'Continuing'
+	            	])
+	            ->onlyOnForms()
+	            ->help('For example: Ended'),
+
+            Date::make('First air date', 'first_aired')
+	            ->format('DD-MM-YYYY')
+	            ->onlyOnForms()
+                ->help('The date on which the show first aired. For example: 2015-12-03'),
+
+            Time::make('Air time', 'air_time')
+	            ->withTwelveHourTime()
+	            ->onlyOnForms()
+	            ->help('The exact time the show airs at. For example: 1:30 PM (13:30)'),
+
+            Select::make('Air day', 'air_day')
+	            ->options([
+                    0 => 'Sunday',
+	            	1 => 'Monday',
+		            2 => 'Tuesday',
+		            3 => 'Wednesday',
+		            4 => 'Thursday',
+		            5 => 'Friday',
+		            6 => 'Saturday'
+	                      ])
+	            ->onlyOnForms()
+	            ->help('The day of the week the show airs at. For example: Thursday'),
 
             Heading::make('Images')
                 ->onlyOnForms(),

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
+        "ext-simplexml": "*",
         "anaseqal/nova-sidebar-icons": "^0.0.2",
         "bensampo/laravel-enum": "^1.16",
         "bugsnag/bugsnag-laravel": "^2.0",
@@ -14,6 +15,7 @@
         "ebess/advanced-nova-media-library": "^2.9",
         "fideloper/proxy": "^4.0",
         "fzaninotto/faker": "^1.8",
+        "laraning/nova-time-field": "^0.2.0",
         "laravel/framework": "5.8.*",
         "laravel/nova": "*",
         "laravel/tinker": "^1.0",
@@ -22,8 +24,7 @@
         "nicolaslopezj/searchable": "1.*",
         "pusher/pusher-php-server": "^3.0",
         "spatie/laravel-medialibrary": "^7.0.0",
-        "timothyasp/nova-color-field": "^1.0",
-        "ext-simplexml": "*"
+        "timothyasp/nova-color-field": "^1.0"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67b5c59e8c76e1269b20b07c222f8f45",
+    "content-hash": "95ab52e9d69cc2149555c27912f4385f",
     "packages": [
         {
             "name": "anaseqal/nova-sidebar-icons",
@@ -1385,6 +1385,47 @@
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
+            "name": "laraning/nova-time-field",
+            "version": "v0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laraning/nova-time-field.git",
+                "reference": "d1d7e081725395674c3f35425bfa8a74d27985d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laraning/nova-time-field/zipball/d1d7e081725395674c3f35425bfa8a74d27985d3",
+                "reference": "d1d7e081725395674c3f35425bfa8a74d27985d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laraning\\NovaTimeField\\FieldServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laraning\\NovaTimeField\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A Laravel Nova field.",
+            "keywords": [
+                "laravel",
+                "nova"
+            ],
+            "time": "2019-09-05T17:55:41+00:00"
+        },
+        {
             "name": "laravel/framework",
             "version": "v5.8.35",
             "source": {
@@ -1538,8 +1579,7 @@
             "dist": {
                 "type": "path",
                 "url": "./nova",
-                "reference": "44b2d572e7dfff707439ada0b0e9c0c608a88ae9",
-                "shasum": null
+                "reference": "44b2d572e7dfff707439ada0b0e9c0c608a88ae9"
             },
             "require": {
                 "cakephp/chronos": "^1.0",

--- a/database/migrations/2018_08_17_103203_create_animes_table.php
+++ b/database/migrations/2018_08_17_103203_create_animes_table.php
@@ -42,6 +42,9 @@ class CreateAnimesTable extends Migration
             $table->integer('rating_count')->default(0);
             $table->integer('episode_count')->default(0);
             $table->integer('season_count')->default(0);
+	        $table->date('first_aired')->nullable();
+	        $table->time('air_time')->nullable();
+	        $table->integer('air_day')->nullable()->unsigned();
 
             // Flags for fetched data
             $table->boolean('fetched_actors')->default(false);


### PR DESCRIPTION
- Added DayOfWeek enum
- Added "first_aired", "air_time" and "air_day" keys to AnimeResource
- Added new "Schedule" section to Nova
- Added "Air status", "First air date", "Air time" and "Air day" fields to Nova
- Added cast rule in Anime to cast "first_aired" to a date
- Added "first_aired", "air_time" and "air_day" in animes table migration file
- Added "laraning/nova-time-field" composer package