### PR TITLE
Store and use anime.json

### DIFF
--- a/app/Console/Commands/MigrateCommand.php
+++ b/app/Console/Commands/MigrateCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Database\Console\Migrations\MigrateCommand as BaseMigrateCommand;
+use Illuminate\Database\Migrations\Migrator;
+
+class MigrateCommand extends BaseMigrateCommand
+{
+    use ConfirmableTrait;
+
+    /**
+     * Create a new migration command instance.
+     *
+     * @param Migrator $migrator
+     * @return void
+     */
+    public function __construct(Migrator $migrator)
+    {
+        $this->signature .= "
+                {--redownload : Indicates if the anime.json should be re-downloaded.}
+        ";
+
+        parent::__construct($migrator);
+    }
+}

--- a/app/Providers/MigrationServiceProvider.php
+++ b/app/Providers/MigrationServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Providers;
+
+use App\Console\Commands\FreshCommand;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Console\Migrations\MigrateCommand;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
+use Illuminate\Database\MigrationServiceProvider as BaseMigrationServiceProvider;
+
+class MigrationServiceProvider extends BaseMigrationServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        parent::register();
+        $this->registerMigrateCommand();
+        $this->registerMigrateFreshCommand();
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateCommand()
+    {
+        $this->app->bindIf(ConnectionResolverInterface::class, 'db');
+        $this->app->bindIf(MigrationRepositoryInterface::class, 'migration.repository');
+        $this->app->singleton('command.migrate', function ($app) {
+            return new MigrateCommand($app['migrator']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateFreshCommand()
+    {
+        $this->app->singleton('command.migrate.fresh', function () {
+            return new FreshCommand;
+        });
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -187,6 +187,7 @@ return [
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         App\Providers\EventServiceProvider::class,
+        App\Providers\MigrationServiceProvider::class,
         App\Providers\NovaServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         App\Providers\UserModelServiceProvider::class,

--- a/database/seeds/AnimesTableDummySeeder.php
+++ b/database/seeds/AnimesTableDummySeeder.php
@@ -20,18 +20,14 @@ class AnimesTableDummySeeder extends Seeder
      */
     public function run()
     {
-        $animeJson = null;
+        $animeJSON = null;
         if(!Storage::exists(self::ANIME_JSON_PATH)) {
-            // Retrieve data from URL
-            $animeJson = file_get_contents(self::ANIME_JSON_FILE);
-
-            // Store data locally
-            Storage::put(self::ANIME_JSON_PATH, $animeJson);
+            $animeJSON = self::storeJSON();
         } else {
-            $animeJson = Storage::get(self::ANIME_JSON_PATH);
+            $animeJSON = Storage::get(self::ANIME_JSON_PATH);
         }
 
-        $parsedAnime = json_decode($animeJson);
+        $parsedAnime = json_decode($animeJSON);
 
         if($parsedAnime != null) {
             // Create the Anime
@@ -45,5 +41,20 @@ class AnimesTableDummySeeder extends Seeder
                 ]);
             }
         }
+    }
+
+    /**
+     * Store and return the stored json.
+     *
+     * @return false|string
+     */
+    static function storeJSON() {
+        // Retrieve data from URL
+        $animeJSON = file_get_contents(self::ANIME_JSON_FILE);
+
+        // Store data locally
+        Storage::put(self::ANIME_JSON_PATH, $animeJSON);
+
+        return $animeJSON;
     }
 }


### PR DESCRIPTION
This PR adds the ability to store and use the anime.json file instead of always downloading it from GitHub. It also extends the `php artisan migrate:fresh --seed` command to redownload the file without extra steps.