### PR TITLE
Make followers and following lists optional

### DIFF
--- a/routes/API/Users.php
+++ b/routes/API/Users.php
@@ -23,10 +23,10 @@ Route::prefix('/users')->group(function() {
         ->middleware('can:follow,user');
 
     Route::get('/{user}/followers', [FollowingController::class, 'getFollowers'])
-        ->middleware('kurozora.userauth');
+        ->middleware('kurozora.userauth:optional');
 
     Route::get('/{user}/following', [FollowingController::class, 'getFollowing'])
-        ->middleware('kurozora.userauth');
+        ->middleware('kurozora.userauth:optional');
 
     Route::get('/{user}/library', [LibraryController::class, 'getLibrary'])
         ->middleware('kurozora.userauth');


### PR DESCRIPTION
This PR makes the followers/following list optional so as everyone can view it without having to authenticate.