### PR TITLE
[Fix] Composer paths in prebuild hooks

### DIFF
--- a/.platform/hooks/prebuild/02-install-composer.sh
+++ b/.platform/hooks/prebuild/02-install-composer.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Get Composer, and install to /usr/local/bin
-if [ ! -f "/usr/bin/composer" ]; then
+if [ ! -f "/usr/local/bin/composer" ]; then
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    php composer-setup.php --install-dir=/usr/bin --filename=composer
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer
     php -r "unlink('composer-setup.php');"
 else
-    /usr/bin/composer self-update --stable --no-ansi --no-interaction
+    /usr/local/bin/composer self-update --stable --no-ansi --no-interaction
 fi


### PR DESCRIPTION
Fixes composer path pointing at /usr/local/bin to point at /usr/bin where composer exists/is being installed.