### PR TITLE
[Fix] WatchStatus

### DIFF
--- a/app/Enums/WatchStatus.php
+++ b/app/Enums/WatchStatus.php
@@ -30,6 +30,6 @@ final class WatchStatus extends Enum
 	 * @return \App\Enums\WatchStatus
 	 */
 	static function init($bool): self {
-		return $bool ? self::WATCHED() : self::NOT_WATCHED();
+		return $bool ? self::Watched() : self::NotWatched();
 	}
 }


### PR DESCRIPTION
- Fixed "enum value doesn't exist" error when creating a WatchStatus instance