### PR TITLE
[Improvement] Date formatting in API response

### DIFF
--- a/app/Anime.php
+++ b/app/Anime.php
@@ -24,6 +24,16 @@ class Anime extends KModel
         ]
     ];
 
+    /**
+     * Casts rules.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'first_aired' => 'date',
+        'last_aired' => 'date'
+    ];
+
     // Maximum amount of returned search results
     const MAX_SEARCH_RESULTS = 10;
 

--- a/app/Http/Resources/AnimeResource.php
+++ b/app/Http/Resources/AnimeResource.php
@@ -46,8 +46,8 @@ class AnimeResource extends JsonResource
             'background_thumbnail'  => $this->getBackground(true),
             'nsfw'                  => (bool) $this->nsfw,
             'genres'                => GenreResource::collection($this->genres),
-            'first_aired'           => $this->first_aired,
-            'last_aired'            => $this->last_aired,
+            'first_aired'           => $this->first_aired->format('Y-m-d'),
+            'last_aired'            => $this->last_aired->format('Y-m-d'),
 	        'air_time'              => $this->air_time,
 	        'air_day'               => $this->air_day
         ];

--- a/app/Nova/Anime.php
+++ b/app/Nova/Anime.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use Laraning\NovaTimeField\TimeField as Time;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\ID;
@@ -155,11 +156,13 @@ class Anime extends Resource
 	            ->hideFromIndex()
 	            ->help('For example: Ended'),
 
-            Text::make('First air date', 'first_aired')
+            Date::make('First aired')
+                ->format('DD-MM-YYYY')
 	            ->hideFromIndex()
                 ->help('The date on which the show first aired. For example: 2015-12-03'),
 
-            Text::make('Last air date', 'last_aired')
+            Date::make('Last aired')
+                ->format('DD-MM-YYYY')
                 ->hideFromIndex()
                 ->help('The date on which the show last aired. For example: 2016-03-08'),
 


### PR DESCRIPTION
Adds date formatting so the API response only returns the date (of first_aired and last_aired) as opposed to date and time. Time is saved separately (in air_time) and having the wrong time sent with both dates complicates date handling on the client.