### PR TITLE
[Fix] Anime & Episode DateTime

### DIFF
--- a/app/Models/AnimeModerator.php
+++ b/app/Models/AnimeModerator.php
@@ -16,8 +16,8 @@ class AnimeModerator extends Pivot
      * @var array
      */
     protected $casts = [
-        'created_at' => 'date',
-        'updated_at' => 'date',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
     ];
 
     /**

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -40,7 +40,7 @@ class Episode extends KModel implements HasMedia
      * @var array
      */
     protected $casts = [
-        'first_aired' => 'date',
+        'first_aired' => 'datetime',
     ];
 
     /**

--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -42,8 +42,8 @@ class Season extends KModel implements HasMedia
      * @var array
      */
     protected $casts = [
-        'first_aired' => 'date',
-        'last_aired' => 'date',
+        'first_aired' => 'datetime',
+        'last_aired' => 'datetime',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -100,7 +100,7 @@ class User extends Authenticatable implements HasMedia, MustVerifyEmail, Reacter
      * @var array
      */
     protected $casts = [
-        'last_mal_import_at' => 'date',
+        'last_mal_import_at' => 'datetime',
         'settings' => 'json',
     ];
 

--- a/app/Nova/Anime.php
+++ b/app/Nova/Anime.php
@@ -260,7 +260,6 @@ class Anime extends Resource
 
             Time::make('Air time')
                 ->withTwelveHourTime()
-                ->withTimezoneAdjustments()
                 ->hideFromIndex()
                 ->help('The exact time the show airs at in JST timezone. For example: 1:30 PM (13:30)')
                 ->nullable(),

--- a/config/app.php
+++ b/config/app.php
@@ -38,7 +38,7 @@ return [
     | or any other location as required by the application or its packages.
     */
 
-    'version' => '1.3.0-alpha.41',
+    'version' => '1.3.0-alpha.42',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- Removed timezone adjustment for air_time from Anime Nova resource
- Fixed date casting for Episode
- Fixed date casting for Season
- Fixed date casting for User