### PR TITLE
[Update] Move Settings Endpoint

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -38,7 +38,7 @@ return [
     | or any other location as required by the application or its packages.
     */
 
-    'version' => '1.3.0-alpha.102',
+    'version' => '1.3.0-alpha.103',
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/Web/Profile.php
+++ b/routes/Web/Profile.php
@@ -6,10 +6,10 @@ use App\Http\Livewire\Profile\Details;
 Route::prefix('/profile')
     ->name('profile')
     ->group(function () {
-        Route::get('/settings', [UserProfileController::class, 'settings'])
-            ->middleware(['auth', 'verified'])
-            ->name('.settings');
-
         Route::get('/{user}', Details::class)
             ->name('.details');
     });
+
+Route::get('/settings', [UserProfileController::class, 'settings'])
+    ->middleware(['auth', 'verified'])
+    ->name('profile.settings');


### PR DESCRIPTION
- Moved settings from /profile/settings to /settings. A user with the username 'settings' should now be able to view their profile page