### PR TITLE
[Fix] MAL Import Process

### DIFF
--- a/app/Jobs/ProcessMALImport.php
+++ b/app/Jobs/ProcessMALImport.php
@@ -207,7 +207,7 @@ class ProcessMALImport implements ShouldQueue
     protected function convertMALDate(string $malDate): ?Carbon
     {
         if ($malDate === '0000-00-00') {
-            return null;
+            return now();
         }
 
         $dateComponents = explode('-', $malDate);

--- a/config/app.php
+++ b/config/app.php
@@ -38,7 +38,7 @@ return [
     | or any other location as required by the application or its packages.
     */
 
-    'version' => '1.3.0-alpha.121',
+    'version' => '1.3.0-alpha.122',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- Fixed an error that occurred when importing start_date with null value. AWS database doesn't default to CURRENT_TIMESTAMP for some reason.